### PR TITLE
Alert users when a hook already exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "source": "https://github.com/stevegrunwell/smee"
     },
     "require": {
-        "symfony/console": "^3.3"
+        "symfony/console": "^3.3",
+        "sebastian/diff": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "89a12aef8b600bdf88a91ca920394dc7",
+    "content-hash": "de85190b520cc5c622f8f1aac3ddc426",
     "packages": [
         {
             "name": "psr/log",
@@ -52,6 +52,58 @@
                 "psr-3"
             ],
             "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "symfony/console",
@@ -1192,58 +1244,6 @@
                 "equality"
             ],
             "time": "2017-08-03T07:14:59+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff"
-            ],
-            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -37,15 +37,33 @@ class InstallCommand extends Command
         $project = new Project($input->getOption('base-dir'), $input->getOption('hooks'));
         $io = new SymfonyStyle($input, $output);
 
+        return $this->executeCommand($project, $io);
+    }
+
+    /**
+     * Method used for running execute(), even if an exception is thrown along the way.
+     *
+     * @param Project      $project
+     * @param SymfonyStyle $io
+     */
+    protected function executeCommand($project, $io)
+    {
         try {
-            $copied = $project->copyHooks();
+            $project->copyHooks();
 
         } catch (Exception $e) {
             $io->getErrorStyle()->error(sprintf('An error occurred while copying git hooks: %s', $e->getMessage()));
             return 1;
         }
 
+        $copied = $project->getCopiedHooks();
+
+        // Nothing was copied, return early.
+        if (empty($copied)) {
+            return;
+        }
+
         $io->section('Copied git hooks:');
-        $io->listing($copied);
+        $io->listing($project->getCopiedHooks());
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -67,16 +67,33 @@ class InstallCommand extends Command
                     $project->copyHook($e->getHook(), true);
                     break;
 
+                // Show differences, then prompt the user what to do.
                 case 'd':
                     $io->write($project->diffHook($e->getHook()));
+                    $secondAsk = $io->choice(
+                        sprintf('A %s hook already exists for this repository, how would you like to proceed?', $e->getHook()),
+                        [
+                            'o' => 'Overwrite',
+                            's' => 'Skip',
+                        ],
+                        'Skip'
+                    );
+
+                    if ('o' === $secondAsk) {
+                        $project->copyHook($e->getHook(), true);
+                    } else {
+                        $project->skipHook($e->getHook());
+                    }
                     break;
 
                 default:
-                    // Mark the current hook as skipped, then re-start the process.
                     $project->skipHook($e->getHook());
-                    $project->copyHooks();
+
                     break;
             }
+
+            // Start the process over again.
+            $project->copyHooks();
         } catch (Exception $e) {
             $io->getErrorStyle()->error(sprintf('An error occurred while copying git hooks: %s', $e->getMessage()));
             return 1;

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -71,7 +71,10 @@ class InstallCommand extends Command
                 case 'd':
                     $io->write($project->diffHook($e->getHook()));
                     $secondAsk = $io->choice(
-                        sprintf('A %s hook already exists for this repository, how would you like to proceed?', $e->getHook()),
+                        sprintf(
+                            'A %s hook already exists for this repository, how would you like to proceed?',
+                            $e->getHook()
+                        ),
                         [
                             'o' => 'Overwrite',
                             's' => 'Skip',

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -3,6 +3,7 @@
 namespace Smee\Console;
 
 use Exception;
+use Smee\Exceptions\HookExistsException;
 use Smee\Project;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Exceptions/HookExistsException.php
+++ b/src/Exceptions/HookExistsException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Smee\Exceptions;
+
+use Exception;
+
+class HookExistsException extends Exception
+{
+
+}

--- a/src/Exceptions/HookExistsException.php
+++ b/src/Exceptions/HookExistsException.php
@@ -6,5 +6,10 @@ use Exception;
 
 class HookExistsException extends Exception
 {
+    public $hook;
 
+    public function getHook()
+    {
+        return $this->hook;
+    }
 }

--- a/src/Project.php
+++ b/src/Project.php
@@ -89,6 +89,12 @@ class Project
         }
 
         if (file_exists($dest)) {
+
+            // The file exists, but it's the same as what we're about to copy.
+            if (md5_file($dest) === md5_file($path)) {
+                return false;
+            }
+
             $exception = new HookExistsException(sprintf('A %s hook already exists for this repository!', $hook));
             $exception->hook = $hook;
 

--- a/src/Project.php
+++ b/src/Project.php
@@ -108,6 +108,14 @@ class Project
         }
     }
 
+    /**
+     * Generate a diff based on the hook name and the project configuration.
+     *
+     * @param string $hook The name of the hook file, which should exist in both .git/hooks and
+     *                     $this->hooksDir.
+     *
+     * @return string A diff of the two files.
+     */
     public function diffHook($hook)
     {
         $file   = $this->hooksDir . '/' . $hook;

--- a/src/Project.php
+++ b/src/Project.php
@@ -98,6 +98,16 @@ class Project
     }
 
     /**
+     * Retrieve an array of copied hooks.
+     *
+     * @return array An array of copied hook names.
+     */
+    public function getCopiedHooks()
+    {
+        return (array) $this->copied;
+    }
+
+    /**
      * Remove trailing slashes from a directory name.
      *
      * @param string $path The path or URL to strip trailing slashes from.

--- a/src/Project.php
+++ b/src/Project.php
@@ -89,7 +89,10 @@ class Project
         }
 
         if (file_exists($dest)) {
-            throw new HookExistsException(sprintf('A %s hook already exists for this repository!', $hook));
+            $exception = new HookExistsException(sprintf('A %s hook already exists for this repository!', $hook));
+            $exception->hook = $hook;
+
+            throw $exception;
         }
 
         if (copy($path, $dest)) {

--- a/src/Project.php
+++ b/src/Project.php
@@ -3,6 +3,7 @@
 namespace Smee;
 
 use Composer\Script\Event;
+use SebastianBergmann\Diff\Differ;
 use Smee\Exceptions\HookExistsException;
 use Smee\Exceptions\NoGitDirectoryException;
 use Smee\Exceptions\NoHooksDirectoryException;
@@ -105,6 +106,29 @@ class Project
         if (copy($path, $dest)) {
             $this->copied[] = $hook;
         }
+    }
+
+    public function diffHook($hook)
+    {
+        $file   = $this->hooksDir . '/' . $hook;
+        $target = $this->baseDir . '/.git/hooks/' . $hook;
+
+        return $this->diffHooks($file, $target);
+    }
+
+    /**
+     * Generate a diff between two hook files.
+     *
+     * @param string $file   The filepath to the new hook file.
+     * @param string $target The filepath to the existing hook file.
+     *
+     * @return string A human-readable diff.
+     */
+    public function diffHooks($file, $target)
+    {
+        $differ = new Differ;
+
+        return $differ->diff(file_get_contents($target), file_get_contents($file));
     }
 
     /**

--- a/src/Project.php
+++ b/src/Project.php
@@ -94,7 +94,7 @@ class Project
         $path = $this->hooksDir . '/' . $hook;
         $dest = $this->baseDir . '/.git/hooks/' . $hook;
 
-        if (is_dir($path)) {
+        if (in_array($hook, $this->skipped, true) || is_dir($path)) {
             return false;
         }
 

--- a/src/Project.php
+++ b/src/Project.php
@@ -168,6 +168,16 @@ class Project
     }
 
     /**
+     * Mark a hook to be skipped.
+     *
+     * @param string $hook The hook name to skip.
+     */
+    public function skipHook($hook)
+    {
+        $this->skipped[] = $hook;
+    }
+
+    /**
      * Remove trailing slashes from a directory name.
      *
      * @param string $path The path or URL to strip trailing slashes from.

--- a/src/Project.php
+++ b/src/Project.php
@@ -17,6 +17,13 @@ class Project
     protected $baseDir;
 
     /**
+     * Contains an array of all Git hooks that have been copied.
+     *
+     * @var array $copied
+     */
+    protected $copied = [];
+
+    /**
      * Contains the path relative to the hooks directory, relative to the project root.
      *
      * @var string $hooksDir
@@ -46,8 +53,6 @@ class Project
      */
     public function copyHooks()
     {
-        $copied = [];
-
         // Throw Exceptions if either the .git or hooks directories are missing.
         if (! is_dir($this->baseDir . '/.git')) {
             throw new NoGitDirectoryException(sprintf('No .git directory was found within %s.', $this->baseDir));
@@ -72,11 +77,11 @@ class Project
             }
 
             if (copy($path, $hook)) {
-                $copied[] = $file;
+                $this->copied[] = $file;
             }
         }
 
-        return $copied;
+        return $this->copied;
     }
 
     /**

--- a/src/Project.php
+++ b/src/Project.php
@@ -3,6 +3,7 @@
 namespace Smee;
 
 use Composer\Script\Event;
+use Smee\Exceptions\HookExistsException;
 use Smee\Exceptions\NoGitDirectoryException;
 use Smee\Exceptions\NoHooksDirectoryException;
 
@@ -60,12 +61,17 @@ class Project
 
         foreach ($contents as $file) {
             $path = $this->hooksDir . '/' . $file;
+            $hook = $dest . basename($file);
 
             if (is_dir($path)) {
                 continue;
             }
 
-            if (copy($path, $dest . basename($file))) {
+            if (file_exists($hook)) {
+                throw new HookExistsException(sprintf('A %s hook already exists for this repository!', $file));
+            }
+
+            if (copy($path, $hook)) {
                 $copied[] = $file;
             }
         }

--- a/src/Project.php
+++ b/src/Project.php
@@ -114,7 +114,10 @@ class Project
 
         if (copy($path, $dest)) {
             $this->copied[] = $hook;
+            return true;
         }
+
+        return false;
     }
 
     /**

--- a/src/Project.php
+++ b/src/Project.php
@@ -106,7 +106,6 @@ class Project
         }
 
         if (file_exists($dest) && ! $force) {
-
             // The file exists, but it's the same as what we're about to copy.
             if (md5_file($dest) === md5_file($path)) {
                 $this->skipHook($hook);
@@ -120,6 +119,7 @@ class Project
         }
 
         // Temporarily hijack the error handler.
+        // @codingStandardsIgnoreLine
         set_error_handler(function () {});
         $copied = copy($path, $dest);
         restore_error_handler();

--- a/src/Project.php
+++ b/src/Project.php
@@ -32,6 +32,13 @@ class Project
     protected $hooksDir;
 
     /**
+     * Contains an array of all Git hooks that have been skipped.
+     *
+     * @var array $skipped
+     */
+    protected $skipped = [];
+
+    /**
      * Instantiate a new project with Smee.
      *
      * @param string $hooksDir Optional. The hooks directory, relative to the project root. Default
@@ -148,6 +155,16 @@ class Project
     public function getCopiedHooks()
     {
         return (array) $this->copied;
+    }
+
+    /**
+     * Retrieve an array of skipped hooks.
+     *
+     * @return array An array of skipped hook names.
+     */
+    public function getSkippedHooks()
+    {
+        return (array) $this->skipped;
     }
 
     /**

--- a/src/Project.php
+++ b/src/Project.php
@@ -102,6 +102,7 @@ class Project
 
             // The file exists, but it's the same as what we're about to copy.
             if (md5_file($dest) === md5_file($path)) {
+                $this->skipHook($hook);
                 return false;
             }
 

--- a/src/Project.php
+++ b/src/Project.php
@@ -74,11 +74,12 @@ class Project
      *
      * @throws HookExistsException If the target hook already exists.
      *
-     * @param string $hook The name of the hook to copy from $this->hooksDir.
+     * @param string $hook  The name of the hook to copy from $this->hooksDir.
+     * @param bool   $force Force overwrite of existing hooks. Default is false.
      *
      * @return bool True if the hook was copied, false if it was ineligible to be copied.
      */
-    public function copyHook($hook)
+    public function copyHook($hook, $force = false)
     {
         $hook = basename($hook);
         $path = $this->hooksDir . '/' . $hook;
@@ -88,7 +89,7 @@ class Project
             return false;
         }
 
-        if (file_exists($dest)) {
+        if (file_exists($dest) && ! $force) {
 
             // The file exists, but it's the same as what we're about to copy.
             if (md5_file($dest) === md5_file($path)) {

--- a/tests/Console/InstallCommandTest.php
+++ b/tests/Console/InstallCommandTest.php
@@ -70,6 +70,23 @@ class InstallCommandTest extends TestCase
         $this->assertContains('post_commit', $output, 'Expected to see "post_commit" listed in the command output.');
     }
 
+    public function testExecuteOnlyShowsSuccessMessageIfHooksWereCopied()
+    {
+        vfsStream::create([
+            '.git' => [
+                'hooks' => [],
+            ],
+            '.githooks' => [],
+        ]);
+
+        $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--base-dir' => $this->root->url(),
+        ]);
+
+        $this->assertEmpty($this->commandTester->getDisplay());
+    }
+
     public function testExecuteHandlesCustomHooksDirectory()
     {
         vfsStream::create([

--- a/tests/Exceptions/HookExistsExceptionTest.php
+++ b/tests/Exceptions/HookExistsExceptionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Smee\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Smee\Exceptions\HookExistsException;
+
+class HookExistsExceptionTest extends TestCase
+{
+    public function testCanRetrieveHook()
+    {
+        $exception = new HookExistsException('Test message');
+        $exception->hook = uniqid();
+
+        $this->assertEquals($exception->hook, $exception->getHook());
+    }
+}

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -235,6 +235,17 @@ EOT;
         $this->assertEquals($hooks, $instance->getCopiedHooks());
     }
 
+    public function testGetSkippedHooks()
+    {
+        $instance = new Project($this->root->url());
+        $hooks = [uniqid()];
+        $property = new ReflectionProperty($instance, 'skipped');
+        $property->setAccessible(true);
+        $property->setValue($instance, $hooks);
+
+        $this->assertEquals($hooks, $instance->getSkippedHooks());
+    }
+
     public function testStripTrailingSlashes()
     {
         $instance = new Project($this->root->url());

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -122,8 +122,15 @@ class ProjectTest extends TestCase
 
         $project = new Project($this->root->url());
 
-        $this->expectException(HookExistsException::class);
-        $project->copyHook('pre-commit');
+        try {
+            $project->copyHook('pre-commit');
+
+        } catch (HookExistsException $e ) {
+            $this->assertEquals('pre-commit', $e->getHook());
+            return;
+        }
+
+        $this->fail('Did not receive expected HookExistsException.');
     }
 
     public function testGetCopiedHooks()

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -6,6 +6,7 @@ use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use ReflectionProperty;
+use Smee\Exceptions\HookExistsException;
 use Smee\Exceptions\NoGitDirectoryException;
 use Smee\Exceptions\NoHooksDirectoryException;
 use Smee\Project;
@@ -106,6 +107,25 @@ class ProjectTest extends TestCase
         $project = new Project($this->root->url());
 
         $this->assertEquals(['pre_commit'], $project->copyHooks());
+    }
+
+    public function testCopyHooksThrowsExceptionIfHookAlreadyExists()
+    {
+        vfsStream::create([
+            '.git' => [
+                'hooks' => [
+                    'pre-commit' => 'Existing pre-commit content',
+                ],
+            ],
+            '.githooks' => [
+                'pre-commit' => 'pre-commit content',
+            ],
+        ]);
+
+        $project = new Project($this->root->url());
+
+        $this->expectException(HookExistsException::class);
+        $project->copyHooks();
     }
 
     public function testStripTrailingSlashes()

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -90,7 +90,7 @@ class ProjectTest extends TestCase
         $project->copyHooks();
     }
 
-    public function testCopyHooksIgnoresDirectories()
+    public function testCopyHookIfHookIsDirectory()
     {
         vfsStream::create([
             '.git' => [
@@ -100,16 +100,14 @@ class ProjectTest extends TestCase
                 'subdirectory' => [
                     'some_file' => 'Some other file',
                 ],
-                'pre_commit' => 'pre_commit content',
             ],
         ]);
 
         $project = new Project($this->root->url());
-
-        $this->assertEquals(['pre_commit'], $project->copyHooks());
+        $this->assertFalse($project->copyHook('subdirectory'), 'Project::copyHook() should return false if the hook is a directory.');
     }
 
-    public function testCopyHooksThrowsExceptionIfHookAlreadyExists()
+    public function testCopyHookThrowsExceptionIfHookAlreadyExists()
     {
         vfsStream::create([
             '.git' => [
@@ -125,7 +123,7 @@ class ProjectTest extends TestCase
         $project = new Project($this->root->url());
 
         $this->expectException(HookExistsException::class);
-        $project->copyHooks();
+        $project->copyHook('pre-commit');
     }
 
     public function testStripTrailingSlashes()

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -138,6 +138,30 @@ class ProjectTest extends TestCase
             file_get_contents($this->root->url() . '/.git/hooks/pre-commit'),
             'The contents of pre-commit should have been copied to .git/hooks/pre-commit.'
         );
+        $this->assertTrue(
+            is_executable($this->root->url() . '/.git/hooks/pre-commit'),
+            'Project::copyHook() should ensure git hooks are executable.'
+        );
+    }
+
+    public function testCopyHookReturnsFalseIfCopyFails()
+    {
+        $dir = vfsStream::create([
+            '.git' => [
+                'hooks' => [],
+            ],
+            '.githooks' => [
+                'pre-commit' => 'pre-commit hook',
+            ],
+        ]);
+        $dir->getChild('.git')->getChild('hooks')->chmod(0444);
+
+        $project = new Project($this->root->url());
+
+        $this->assertFalse(
+            $project->copyHook('pre-commit'),
+            'The hook should not have been able to be copied, due to file permissions.'
+        );
     }
 
     public function testCopyHookIfHookIsDirectory()

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -158,6 +158,11 @@ class ProjectTest extends TestCase
         $project->copyHook('pre-commit');
 
         $this->assertEmpty($project->getCopiedHooks());
+        $this->assertContains(
+            'pre-commit',
+            $project->getSkippedHooks(),
+            'The pre-commit hook should be added to Project::$skipped.'
+        );
     }
 
     public function testCopyHookCanForceOverwrite()

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -126,6 +126,17 @@ class ProjectTest extends TestCase
         $project->copyHook('pre-commit');
     }
 
+    public function testGetCopiedHooks()
+    {
+        $instance = new Project($this->root->url());
+        $hooks = [uniqid()];
+        $property = new ReflectionProperty($instance, 'copied');
+        $property->setAccessible(true);
+        $property->setValue($instance, $hooks);
+
+        $this->assertEquals($hooks, $instance->getCopiedHooks());
+    }
+
     public function testStripTrailingSlashes()
     {
         $instance = new Project($this->root->url());

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -147,9 +147,29 @@ class ProjectTest extends TestCase
         ]);
 
         $project = new Project($this->root->url());
-        $project->copyHooks();
+        $project->copyHook('pre-commit');
 
         $this->assertEmpty($project->getCopiedHooks());
+    }
+
+    public function testCopyHookCanForceOverwrite()
+    {
+        vfsStream::create([
+            '.git' => [
+                'hooks' => [
+                    'pre-commit' => 'old pre-commit content',
+                ],
+            ],
+            '.githooks' => [
+                'pre-commit' => 'new pre-commit content',
+            ],
+        ]);
+
+        $project = new Project($this->root->url());
+        $project->copyHook('pre-commit', true);;
+
+        $this->assertContains('pre-commit', $project->getCopiedHooks());
+        $this->assertEquals('new pre-commit content', file_get_contents($this->root->url() . '/.git/hooks/pre-commit'));
     }
 
     public function testGetCopiedHooks()

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -246,6 +246,18 @@ EOT;
         $this->assertEquals($hooks, $instance->getSkippedHooks());
     }
 
+    public function testSkipHook()
+    {
+        $instance = new Project($this->root->url());
+        $hook = uniqid();
+        $property = new ReflectionProperty($instance, 'skipped');
+        $property->setAccessible(true);
+
+        $instance->skipHook($hook);
+
+        $this->assertContains($hook, $property->getValue($instance));
+    }
+
     public function testStripTrailingSlashes()
     {
         $instance = new Project($this->root->url());

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -133,6 +133,25 @@ class ProjectTest extends TestCase
         $this->fail('Did not receive expected HookExistsException.');
     }
 
+    public function testCopyHookIgnoresExistingHooksThatMatchWhatIsBeingCopied()
+    {
+        vfsStream::create([
+            '.git' => [
+                'hooks' => [
+                    'pre-commit' => 'pre-commit content',
+                ],
+            ],
+            '.githooks' => [
+                'pre-commit' => 'pre-commit content',
+            ],
+        ]);
+
+        $project = new Project($this->root->url());
+        $project->copyHooks();
+
+        $this->assertEmpty($project->getCopiedHooks());
+    }
+
     public function testGetCopiedHooks()
     {
         $instance = new Project($this->root->url());

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -98,6 +98,24 @@ class ProjectTest extends TestCase
         $project->copyHooks();
     }
 
+    public function testCopyHooksIgnoresHooksInSkippedArray()
+    {
+        vfsStream::create([
+            '.git' => [
+                'hooks' => [],
+            ],
+            '.githooks' => [
+                'pre-commit' => 'pre-commit hook',
+            ],
+        ]);
+
+        $project = new Project($this->root->url());
+        $project->skipHook('pre-commit');
+
+        $this->assertFalse($project->copyHook('pre-commit'));
+        $this->assertEmpty($project->getCopiedHooks());
+    }
+
     public function testCopyHookIfHookIsDirectory()
     {
         vfsStream::create([

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -179,7 +179,11 @@ class ProjectTest extends TestCase
         ]);
 
         $project = new Project($this->root->url());
-        $this->assertFalse($project->copyHook('subdirectory'), 'Project::copyHook() should return false if the hook is a directory.');
+
+        $this->assertFalse(
+            $project->copyHook('subdirectory'),
+            'Project::copyHook() should return false if the hook is a directory.'
+        );
     }
 
     public function testCopyHookThrowsExceptionIfHookAlreadyExists()
@@ -199,8 +203,7 @@ class ProjectTest extends TestCase
 
         try {
             $project->copyHook('pre-commit');
-
-        } catch (HookExistsException $e ) {
+        } catch (HookExistsException $e) {
             $this->assertEquals('pre-commit', $e->getHook());
             return;
         }
@@ -246,10 +249,15 @@ class ProjectTest extends TestCase
         ]);
 
         $project = new Project($this->root->url());
-        $project->copyHook('pre-commit', true);;
+
+        $project->copyHook('pre-commit', true);
 
         $this->assertContains('pre-commit', $project->getCopiedHooks());
-        $this->assertEquals('new pre-commit content', file_get_contents($this->root->url() . '/.git/hooks/pre-commit'));
+        $this->assertEquals(
+            'new pre-commit content',
+            file_get_contents($this->root->url() . '/.git/hooks/pre-commit'),
+            'If forced, the target hook should be overwritten.'
+        );
     }
 
     public function testDiffHook()
@@ -293,7 +301,13 @@ EOT;
 +new pre-commit content
 EOT;
 
-        $this->assertContains($diff, $project->diffHooks($this->root->url() . '/.githooks/pre-commit', $this->root->url() . '/.git/hooks/pre-commit'));
+        $this->assertContains(
+            $diff,
+            $project->diffHooks(
+                $this->root->url() . '/.githooks/pre-commit',
+                $this->root->url() . '/.git/hooks/pre-commit'
+            )
+        );
     }
 
     public function testGetCopiedHooks()

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -172,6 +172,50 @@ class ProjectTest extends TestCase
         $this->assertEquals('new pre-commit content', file_get_contents($this->root->url() . '/.git/hooks/pre-commit'));
     }
 
+    public function testDiffHook()
+    {
+        vfsStream::create([
+            '.git' => [
+                'hooks' => [
+                    'pre-commit' => 'old pre-commit content',
+                ],
+            ],
+            '.githooks' => [
+                'pre-commit' => 'new pre-commit content',
+            ],
+        ]);
+
+        $project = new Project($this->root->url());
+        $diff = <<<EOT
+-old pre-commit content
++new pre-commit content
+EOT;
+
+        $this->assertContains($diff, $project->diffHook('pre-commit'));
+    }
+
+    public function testDiffHooks()
+    {
+        vfsStream::create([
+            '.git' => [
+                'hooks' => [
+                    'pre-commit' => 'old pre-commit content',
+                ],
+            ],
+            '.githooks' => [
+                'pre-commit' => 'new pre-commit content',
+            ],
+        ]);
+
+        $project = new Project($this->root->url());
+        $diff = <<<EOT
+-old pre-commit content
++new pre-commit content
+EOT;
+
+        $this->assertContains($diff, $project->diffHooks($this->root->url() . '/.githooks/pre-commit', $this->root->url() . '/.git/hooks/pre-commit'));
+    }
+
     public function testGetCopiedHooks()
     {
         $instance = new Project($this->root->url());

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -116,6 +116,30 @@ class ProjectTest extends TestCase
         $this->assertEmpty($project->getCopiedHooks());
     }
 
+    public function testCopyHook()
+    {
+        vfsStream::create([
+            '.git' => [
+                'hooks' => [],
+            ],
+            '.githooks' => [
+                'pre-commit' => 'pre-commit hook',
+            ],
+        ]);
+
+        $project = new Project($this->root->url());
+
+        $this->assertTrue(
+            $project->copyHook('pre-commit'),
+            'Project::copyHook() should return a boolean TRUE if copy was successful.'
+        );
+        $this->assertEquals(
+            'pre-commit hook',
+            file_get_contents($this->root->url() . '/.git/hooks/pre-commit'),
+            'The contents of pre-commit should have been copied to .git/hooks/pre-commit.'
+        );
+    }
+
     public function testCopyHookIfHookIsDirectory()
     {
         vfsStream::create([


### PR DESCRIPTION
This PR was originally meant to be a solution for #1, but in the interest of keeping the scope low I'm going to bump #1 from the 1.0.0 milestone.

What this branch _does_ do, however, is detect conflicts between hooks that should be copied and those that might already exist. When this happens, the user will be prompted how they wish to handle the conflict: skip the new hook, overwrite the existing hook, or show a diff between the two (followed by a prompt to skip or overwrite).

This PR also handles exceptions that may come up during the copying of a single hook, with logic that enables the process to resume where it left off.

63a4f53, contained within this commit, also fixes #9.